### PR TITLE
Disable list of commands from playground repositories

### DIFF
--- a/internal/server/httpServer.go
+++ b/internal/server/httpServer.go
@@ -97,6 +97,10 @@ func (s *HTTPServer) HealthCheck(w http.ResponseWriter, request *http.Request) {
 func (s *HTTPServer) CliHandler(w http.ResponseWriter, r *http.Request) {
 	diceCmd, err := util.ParseHTTPRequest(r)
 	if err != nil {
+		if util.IsBlacklistedCommand(err) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, "Error parsing HTTP request", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
This PR focuses on a blacklist feature that does not allow a set of commands to run in the DiceDB Playground project.
fixes DiceDB/dice#897
**Changes**

1.  Updated helpers.go:
      - Added a service layer to intercept and reject the request.
2. Updated httpServer.go:
      - Implement the service layer and reject with a forbidden status

![image](https://github.com/user-attachments/assets/8b8ad880-ec33-42fc-a093-2bbcae1bfb3e)

**Testing**
  - Verified that commands listed in the blacklist are properly rejected with the correct error message.
  - Confirmed that all other commands function as expected.
