### PR TITLE
Fix docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,10 @@ services:
       - dicedbadmin
       - dicedb
     environment:
-      - DICEDB_ADMIN_ADDR=localhost:7379
+      - DICEDB_ADMIN_ADDR=dicedbadmin:7379
       - DICEDB_ADMIN_USERNAME=${DICEDB_ADMIN_USERNAME}
       - DICEDB_ADMIN_PASSWORD=${DICEDB_ADMIN_PASSWORD}
-      - DICEDB_ADDR=localhost:7380
+      - DICEDB_ADDR=dicedb:7379
       - DICEDB_USERNAME=${DICEDB_USERNAME}
       - DICEDB_PASSWORD=${DICEDB_PASSWORD}
     networks:


### PR DESCRIPTION
- Output:
```
[+] Running 3/0
 ✔ Container playground-mono-dicedbadmin-1  Created                                                                                      0.0s
 ✔ Container playground-mono-dicedb-1       Created                                                                                      0.0s
 ✔ Container playground-mono-backend-1      Created                                                                                      0.0s
Attaching to backend-1, dicedb-1, dicedbadmin-1
dicedbadmin-1  |
dicedbadmin-1  | ██████╗ ██╗ ██████╗███████╗██████╗ ██████╗
dicedbadmin-1  | ██╔══██╗██║██╔════╝██╔════╝██╔══██╗██╔══██╗
dicedbadmin-1  | ██║  ██║██║██║     █████╗  ██║  ██║██████╔╝
dicedbadmin-1  | ██║  ██║██║██║     ██╔══╝  ██║  ██║██╔══██╗
dicedbadmin-1  | ██████╔╝██║╚██████╗███████╗██████╔╝██████╔╝
dicedbadmin-1  | ╚═════╝ ╚═╝ ╚═════╝╚══════╝╚═════╝ ╚═════╝
dicedbadmin-1  |
dicedb-1       |
dicedb-1       | ██████╗ ██╗ ██████╗███████╗██████╗ ██████╗
dicedb-1       | ██╔══██╗██║██╔════╝██╔════╝██╔══██╗██╔══██╗
dicedbadmin-1  | 2024-10-26T17:05:17Z INF starting DiceDB version=0.0.5
dicedb-1       | ██║  ██║██║██║     █████╗  ██║  ██║██████╔╝
dicedbadmin-1  | 2024-10-26T17:05:17Z INF running with port=7379
dicedb-1       | ██║  ██║██║██║     ██╔══╝  ██║  ██║██╔══██╗
dicedbadmin-1  | 2024-10-26T17:05:17Z INF running with enable-watch=false
dicedb-1       | ██████╔╝██║╚██████╗███████╗██████╔╝██████╔╝
dicedb-1       | ╚═════╝ ╚═╝ ╚═════╝╚══════╝╚═════╝ ╚═════╝
dicedb-1       |
dicedbadmin-1  | 2024-10-26T17:05:17Z INF running with mode=single-threaded
dicedbadmin-1  | 2024-10-26T17:05:17Z WRN running without authentication, consider setting a password
dicedb-1       | 2024-10-26T17:05:17Z INF starting DiceDB version=0.0.5
dicedb-1       | 2024-10-26T17:05:17Z INF running with port=7379
dicedb-1       | 2024-10-26T17:05:17Z INF running with enable-watch=false
dicedb-1       | 2024-10-26T17:05:17Z INF running with mode=single-threaded
dicedb-1       | 2024-10-26T17:05:17Z WRN running without authentication, consider setting a password
backend-1      | 2024/10/26 17:05:17 INFO starting HTTP server at addr=:8080
```